### PR TITLE
document SASL target change

### DIFF
--- a/docs/3/configuration-changes.md
+++ b/docs/3/configuration-changes.md
@@ -50,6 +50,8 @@ NOTE: This document only lists breaking changes between InspIRCd 2 and InspIRCd 
 
 - `<xlinedb:filename>` is now relative to the data directory. Generally all you will need to do in order to upgrade is remove `data/` from the path.
 
+- `<sasl:target>` is now required. The module cannot be loaded unless a target is supplied.
+
 ## Moves
 
 - The `/MODENOTICE` command has been moved to the new modenotice module. See the documentation in modules.conf.example for more details.

--- a/docs/3/configuration-changes.md
+++ b/docs/3/configuration-changes.md
@@ -46,11 +46,11 @@ NOTE: This document only lists breaking changes between InspIRCd 2 and InspIRCd 
 
 - `<permchanneldb:filename>` is now relative to the config directory. Generally all you will need to do in order to upgrade is move `permchannels.conf` to `conf/` and remove `data/` from the path.
 
+- `<sasl:target>` is now required. The module cannot be loaded unless a target is supplied.
+
 - `<type:name>` can now contain spaces. Any underscores in the type name will no longer be replaced with spaces. To keep v2 behaviour replace any underscores with spaces.
 
 - `<xlinedb:filename>` is now relative to the data directory. Generally all you will need to do in order to upgrade is remove `data/` from the path.
-
-- `<sasl:target>` is now required. The module cannot be loaded unless a target is supplied.
 
 ## Moves
 


### PR DESCRIPTION
In insp3, SASL's `target` field is now required. This change broke SASL in inspircd-docker during the upgrade to insp3 and might be worth mentioning on this page.