### PR TITLE
Change services_account channel mode from L to R

### DIFF
--- a/docs/3/modules/services_account.md
+++ b/docs/3/modules/services_account.md
@@ -23,7 +23,7 @@ This module requires no other configuration.
 Name         | Character | Type   | Parameter Syntax | Description
 ------------ | --------- | ------ | ---------------- | -----------
 c_registered | r         | Switch | *None*           | Marks the channel as being registered.
-reginvite    | L         | Switch | *None*           | Prevents users who are not logged into a services account from joining the channel.
+reginvite    | R         | Switch | *None*           | Prevents users who are not logged into a services account from joining the channel.
 regmoderated | M         | Switch | *None*           | Prevents users who are not logged into a services account from speaking in the channel.
 
 ### User Modes


### PR DESCRIPTION
The channel mode is wrong - [it's `+R` and not `+L`][1]

I'm also curious whether it's intentional that the channel mode `regdeaf` collides with `reginvite` (both are `+R` - probably a bug?)

I've refrained from also fixing `regdeaf` because of that.

[1]: https://github.com/inspircd/inspircd/blob/7ad534c1af4578a0d46742c4b6b00a5a33afb63f/src/modules/m_services_account.cpp#L162]