### PR TITLE
Slight improvments to the sslinfo and sslmodes

### DIFF
--- a/docs/2/modules/index.md
+++ b/docs/2/modules/index.md
@@ -143,7 +143,7 @@ Name                                            | Description
 [spanningtree](/2/modules/spanningtree)         | Allows servers to be linked.
 [sqlauth](/2/modules/sqlauth)                   | Allow/Deny connections based upon an arbitrary SQL table.
 [sqloper](/2/modules/sqloper)                   | Allows storage of oper credentials in an SQL table.
-[sslinfo](/2/modules/sslinfo)                   | SSL Certificate Utilities.
+[sslinfo](/2/modules/sslinfo)                   | Provides user SSL information and certificate utilities.
 [sslmodes](/2/modules/sslmodes)                 | Provides channel mode +z to allow for Secure/SSL only channels.
 [stripcolor](/2/modules/stripcolor)             | Provides channel +S mode (strip ansi color).
 [svshold](/2/modules/svshold)                   | Implements SVSHOLD. Like Q:Lines, but can only be added/removed by Services.

--- a/docs/2/modules/sslinfo.md
+++ b/docs/2/modules/sslinfo.md
@@ -8,7 +8,7 @@ title: Module Details (sslinfo)
 
 ### Description
 
-This module adds the `/SSLINFO` command which allows users to look up SSL certificate information for other users.
+This module adds user facing SSL information, various SSL configuration options, and the `/SSLINFO` command to look up SSL certificate information for other users.
 
 ### Configuration
 

--- a/docs/3/modules/index.md
+++ b/docs/3/modules/index.md
@@ -167,7 +167,7 @@ Name                                                      | Description
 [spanningtree](/3/modules/spanningtree)                   | Allows servers to be linked
 [sqlauth](/3/modules/sqlauth)                             | Allow/deny connections based upon an arbitrary SQL table
 [sqloper](/3/modules/sqloper)                             | Allows storage of oper credentials in an SQL table
-[sslinfo](/3/modules/sslinfo)                             | SSL Certificate Utilities
+[sslinfo](/3/modules/sslinfo)                             | Provides user SSL information and certificate utilities
 [sslmodes](/3/modules/sslmodes)                           | Provides user and channel mode +z to allow for SSL-only channels, queries and notices
 [starttls](/3/modules/starttls)                           | Provides the STARTTLS command
 [stripcolor](/3/modules/stripcolor)                       | Provides channel mode +S, strip ansi color

--- a/docs/3/modules/sslinfo.md
+++ b/docs/3/modules/sslinfo.md
@@ -6,7 +6,7 @@ title: Module Details (sslinfo)
 
 ### Description
 
-This module adds the `/SSLINFO` command which allows users to look up SSL certificate information for other users.
+This module adds user facing SSL information, various SSL configuration options, and the `/SSLINFO` command to look up SSL certificate information for other users.
 
 ### Configuration
 

--- a/docs/3/modules/sslmodes.md
+++ b/docs/3/modules/sslmodes.md
@@ -6,7 +6,7 @@ title: Module Details (sslmodes)
 
 ### Description
 
-This module adds channel mode `z` (sslonly) which prevents users who are not connecting using SSL from joining the channel.
+This module adds channel mode `z` (sslonly) which prevents users who are not connecting using SSL from joining the channel and user mode `z` (sslqueries) to prevent messages from non-SSL users.
 
 ### Configuration
 


### PR DESCRIPTION
- Describe `sslinfo` a little more so users know it's more than just a command.
- Add the sslqueries user mode to `sslmodes` description.