### PR TITLE
Correct the descriptions for the insane tag.

### DIFF
--- a/docs/2/configuration/_insane.md
+++ b/docs/2/configuration/_insane.md
@@ -6,16 +6,16 @@ The `<insane>` tag defines limits to protect against overly wide X-lines being c
 
 Name      | Type    | Default Value | Description
 --------- | ------- | ------------- | -----------
-hostmasks | Boolean | No            | Whether to apply the limit to E-lines, G-lines, and K-lines.
-ipmasks   | Boolean | No            | Whether to apply the limit to Z-lines.
-nickmasks | Boolean | No            | Whether to apply the limit to Q-lines.
+hostmasks | Boolean | No            | Whether to bypass the limit for E-lines, G-lines, and K-lines.
+ipmasks   | Boolean | No            | Whether to bypass the limit for Z-lines.
+nickmasks | Boolean | No            | Whether to bypass the limit for Q-lines.
 trigger   | Decimal | 95.5          | The percentage of connected users who must match the X-line for it to be rejected as overly wide.
 
 #### Example Usage
 
 ```xml
-<insane hostmasks="yes"
-        ipmasks="yes"
-        nickmasks="yes"
+<insane hostmasks="no"
+        ipmasks="no"
+        nickmasks="no"
         trigger="95.5">
 ```


### PR DESCRIPTION
The yes/no flags for each ban type are used to bypass the insane ban check; not whether to apply the check.
This actually caused me to change my network's config during the upgrade from v2 to v3, whoops. :smile:

Reference: [Example Conf](https://github.com/inspircd/inspircd/blob/insp3/docs/conf/inspircd.conf.example#L1002-L1028)
Reference: [InsaneBan::MatchesEveryone](https://github.com/inspircd/inspircd/blob/insp3/src/coremods/core_xline/core_xline.cpp#L32-L33)