### PR TITLE
Minor doc improvements

### DIFF
--- a/docs/3/modules/pgsql.md
+++ b/docs/3/modules/pgsql.md
@@ -44,7 +44,7 @@ name   | Text    | *None*        | **Required!** The name of the PostgreSQL data
 <database module="pgsql"
           id="opers"
           host="localhost"
-          port="3306"
+          port="5432"
           ssl="yes"
           user="ircd_opers"
           pass="changeme"

--- a/docs/3/modules/sqlauth.md
+++ b/docs/3/modules/sqlauth.md
@@ -23,7 +23,7 @@ The `<sqlauth>` tag defines settings about how the sqlauth module should behave.
 Name         | Type    | Default Value | Description
 ------------ | ------- | ------------- | -----------
 allowpattern | Text    | *None*        | If defined then a glob pattern for nicknames that are exempted from the authentication requirement.
-column       | Text    | *None*        | **Required!** The name of the column that the password is located in.
+column       | Text    | *None*        | The name of the column that the password is located in.
 dbid         | Text    | *None*        | **Required!** The name of the database connection to execute the query against.
 hash         | Text    | md5,sha256    | A comma-delimited list of hash algorithms to check the password against.
 kdf          | Text    | *None*        | The name of a KDF to check the password against.


### PR DESCRIPTION
Came across these while reading docs:

- default port for pgsql is 5432 (3306 is mysql's)
- column is not required in <sqlauth>
