### PR TITLE
Sqloper doc additions

### DIFF
--- a/docs/3/configuration/_oper.md
+++ b/docs/3/configuration/_oper.md
@@ -4,18 +4,15 @@
 
 The `<oper>` tag defines a server operator account. This tag can be defined as many times as required.
 
-Name        | Type    | Default Value | Description
------------ | ------- | ------------- | -----------
-autologin   | Boolean | No            | If a fingerprint for this oper is specified, automatically log them in.
-class       | Text    | *None*        | If defined then a connect class to assign users who log into this server operator account to.
-fingerprint | Text    | *None*        | A space separated list of of TLS client certificate fingerprints. These can be obtained by using the /SSLINFO command while the module is loaded, and is also noticed on connect.
-hash        | Text    | *None*        | If defined then the hash algorithm that the password field is hashed with.
-host        | Text    | *None*        | **Required!** A space-delimited list of glob patterns for the username@hostname mask that users must be connecting from to log into this server operator account.
-name        | Text    | *None*        | **Required!** The username for this server operator account.
-password    | Text    | *None*        | **Required!** The password for this server operator account.
-sslonly     | Boolean | No            | If enabled, this oper can only oper up if they're using a TLS (SSL) connection.  This setting only takes effect if the sslinfo module is loaded.
-type        | Text    | *None*        | **Required!** The type of server operator this account is.
-vhost       | Text    | *None*        | If defined then a virtual hostname to set on users who log into this server operator account.
+Name     | Type | Default Value | Description
+-------- | ---- | ------------- | -----------
+class    | Text | *None*        | If defined then a connect class to assign users who log into this server operator account to.
+hash     | Text | *None*        | If defined then the hash algorithm that the password field is hashed with.
+host     | Text | *None*        | **Required!** A space-delimited list of glob patterns for the username@hostname mask that users must be connecting from to log into this server operator account.
+name     | Text | *None*        | **Required!** The username for this server operator account.
+password | Text | *None*        | **Required!** The password for this server operator account.
+type     | Text | *None*        | **Required!** The type of server operator this account is.
+vhost    | Text | *None*        | If defined then a virtual hostname to set on users who log into this server operator account.
 
 {! 3/modules/_hash_table.md !}
 
@@ -30,5 +27,3 @@ vhost       | Text    | *None*        | If defined then a virtual hostname to se
       type="NetAdmin"
       vhost="staff.example.net">
 ```
-
-

--- a/docs/3/configuration/_oper.md
+++ b/docs/3/configuration/_oper.md
@@ -30,3 +30,5 @@ vhost       | Text    | *None*        | If defined then a virtual hostname to se
       type="NetAdmin"
       vhost="staff.example.net">
 ```
+
+

--- a/docs/3/configuration/_oper.md
+++ b/docs/3/configuration/_oper.md
@@ -4,15 +4,18 @@
 
 The `<oper>` tag defines a server operator account. This tag can be defined as many times as required.
 
-Name     | Type | Default Value | Description
--------- | ---- | ------------- | -----------
-class    | Text | *None*        | If defined then a connect class to assign users who log into this server operator account to.
-hash     | Text | *None*        | If defined then the hash algorithm that the password field is hashed with.
-host     | Text | *None*        | **Required!** A space-delimited list of glob patterns for the username@hostname mask that users must be connecting from to log into this server operator account.
-name     | Text | *None*        | **Required!** The username for this server operator account.
-password | Text | *None*        | **Required!** The password for this server operator account.
-type     | Text | *None*        | **Required!** The type of server operator this account is.
-vhost    | Text | *None*        | If defined then a virtual hostname to set on users who log into this server operator account.
+Name        | Type    | Default Value | Description
+----------- | ------- | ------------- | -----------
+autologin   | Boolean | No            | If a fingerprint for this oper is specified, automatically log them in.
+class       | Text    | *None*        | If defined then a connect class to assign users who log into this server operator account to.
+fingerprint | Text    | *None*        | A space separated list of of TLS client certificate fingerprints. These can be obtained by using the /SSLINFO command while the module is loaded, and is also noticed on connect.
+hash        | Text    | *None*        | If defined then the hash algorithm that the password field is hashed with.
+host        | Text    | *None*        | **Required!** A space-delimited list of glob patterns for the username@hostname mask that users must be connecting from to log into this server operator account.
+name        | Text    | *None*        | **Required!** The username for this server operator account.
+password    | Text    | *None*        | **Required!** The password for this server operator account.
+sslonly     | Boolean | No            | If enabled, this oper can only oper up if they're using a TLS (SSL) connection.  This setting only takes effect if the sslinfo module is loaded.
+type        | Text    | *None*        | **Required!** The type of server operator this account is.
+vhost       | Text    | *None*        | If defined then a virtual hostname to set on users who log into this server operator account.
 
 {! 3/modules/_hash_table.md !}
 
@@ -27,3 +30,5 @@ vhost    | Text | *None*        | If defined then a virtual hostname to set on u
       type="NetAdmin"
       vhost="staff.example.net">
 ```
+
+

--- a/docs/3/configuration/_oper.md
+++ b/docs/3/configuration/_oper.md
@@ -8,7 +8,7 @@ Name        | Type    | Default Value | Description
 ----------- | ------- | ------------- | -----------
 autologin   | Boolean | No            | If a fingerprint for this oper is specified, automatically log them in.
 class       | Text    | *None*        | If defined then a connect class to assign users who log into this server operator account to.
-fingerprint | Text    | *None*        | A space separated list of TLS client certificate fingerprints. These can be obtained by using the /SSLINFO command while the module is loaded, and is also noticed on connect.
+fingerprint | Text    | *None*        | A space separated list of of TLS client certificate fingerprints. These can be obtained by using the /SSLINFO command while the module is loaded, and is also noticed on connect.
 hash        | Text    | *None*        | If defined then the hash algorithm that the password field is hashed with.
 host        | Text    | *None*        | **Required!** A space-delimited list of glob patterns for the username@hostname mask that users must be connecting from to log into this server operator account.
 name        | Text    | *None*        | **Required!** The username for this server operator account.

--- a/docs/3/configuration/_oper.md
+++ b/docs/3/configuration/_oper.md
@@ -8,7 +8,7 @@ Name        | Type    | Default Value | Description
 ----------- | ------- | ------------- | -----------
 autologin   | Boolean | No            | If a fingerprint for this oper is specified, automatically log them in.
 class       | Text    | *None*        | If defined then a connect class to assign users who log into this server operator account to.
-fingerprint | Text    | *None*        | A space separated list of of TLS client certificate fingerprints. These can be obtained by using the /SSLINFO command while the module is loaded, and is also noticed on connect.
+fingerprint | Text    | *None*        | A space separated list of TLS client certificate fingerprints. These can be obtained by using the /SSLINFO command while the module is loaded, and is also noticed on connect.
 hash        | Text    | *None*        | If defined then the hash algorithm that the password field is hashed with.
 host        | Text    | *None*        | **Required!** A space-delimited list of glob patterns for the username@hostname mask that users must be connecting from to log into this server operator account.
 name        | Text    | *None*        | **Required!** The username for this server operator account.

--- a/docs/3/configuration/_oper.md
+++ b/docs/3/configuration/_oper.md
@@ -30,5 +30,3 @@ vhost       | Text    | *None*        | If defined then a virtual hostname to se
       type="NetAdmin"
       vhost="staff.example.net">
 ```
-
-

--- a/docs/3/modules/sqloper.md
+++ b/docs/3/modules/sqloper.md
@@ -34,8 +34,16 @@ query | Text | SELECT * FROM ircd_opers WHERE active=1 | The SQL query to retrie
          query="SELECT * FROM ircd_opers WHERE active=1">
 ```
 
+```xml
+<sqloper dbid="sqloper"
+         query="SELECT username as name, '*' as host, oper_class as type, sha256_password as password, 'sha256' as hash FROM users WHERE oper_class IS NOT NULL">
+```
+
+ For each row an <oper> will be defined using the field values returned. See the [<oper> configuration docs](https://docs.inspircd.org/3/configuration/#ltopergt) for column names, default values and required columns.
+
+
 ### Special Notes
 
 {! 3/modules/_sql_table.md !}
 
-Schemas for the server operator database are available in [the `sql` subdirectory of the InspIRCd configuration directory](https://github.com/inspircd/inspircd/tree/master/docs/sql).
+Example schemas for the server operator database are available in [the `sql` subdirectory of the InspIRCd configuration directory](https://github.com/inspircd/inspircd/tree/master/docs/sql). You can define your own schema as long as your query returns the required columns.

--- a/docs/3/modules/sqloper.md
+++ b/docs/3/modules/sqloper.md
@@ -41,7 +41,6 @@ query | Text | SELECT * FROM ircd_opers WHERE active=1 | The SQL query to retrie
 
  For each row an <oper> will be defined using the field values returned. See the [<oper> configuration docs](https://docs.inspircd.org/3/configuration/#ltopergt) for column names, default values and required columns.
 
-
 ### Special Notes
 
 {! 3/modules/_sql_table.md !}


### PR DESCRIPTION
Explains how the sqloper query is used to create opers, with addition info on the oper configuration options.