### PR TITLE
Add CVE identifiers to security advisories

### DIFF
--- a/docs/security/2019-01.md
+++ b/docs/security/2019-01.md
@@ -32,3 +32,4 @@ If upgrading is not possible then the silence module should be unloaded.
 
 * [InspIRCd commit bcd65de](https://github.com/inspircd/inspircd/commit/bcd65de1ec4bb71591ae417fee649d7ecd37cd57).
 * [InspIRCd commit 7b47de3](https://github.com/inspircd/inspircd/commit/7b47de3c194f239c5fea09a0e49696c9af017d51).
+* [CVE-2019-20918](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20918)

--- a/docs/security/2019-02.md
+++ b/docs/security/2019-02.md
@@ -31,3 +31,4 @@ If upgrading is not possible then the mysql module should be unloaded.
 
 * [InspIRCd commit 2cc35d8 (v2)](https://github.com/inspircd/inspircd/commit/2cc35d8625b7ea5cbd1d1ebb116aff86c5280162).
 * [InspIRCd commit 8745660 (v3)](https://github.com/inspircd/inspircd/commit/8745660fcdac7c1b80c94cfc0ff60928cd4dd4b7).
+* [CVE-2019-20917](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-20917)

--- a/docs/security/2020-01.md
+++ b/docs/security/2020-01.md
@@ -31,3 +31,4 @@ If upgrading is not possible then the pgsql module should be unloaded.
 
 * [InspIRCd commits 6f6fa13, a9e107c, and 07d7dea (v2)](https://github.com/inspircd/inspircd/compare/v2.0.28...07d7dea).
 * [InspIRCd commits b24a911, fbdd080, and b3f1db9 (v3)](https://github.com/inspircd/inspircd/compare/426d1c8...b3f1db9).
+* [CVE-2020-25269](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25269)


### PR DESCRIPTION
These CVE IDs were recently assigned by MITRE to track the vulnerabilities disclosed in InspIRCd Security Advisories 2019-01, 2019-02, and 2020-01. We should update these advisories to reference their CVE IDs.

It may take a day or so before the CVE pages will load on the MITRE website as the IDs were only just assigned today.

My hope is by obtaining CVE IDs for these vulnerabilities we can more quickly get these security patches into downstream Linux distributions.