### PR TITLE
Fix linter error about 3 consecutive newlines

### DIFF
--- a/docs/3/commands/_cmd_servlist.md
+++ b/docs/3/commands/_cmd_servlist.md
@@ -2,7 +2,6 @@
 
 ### `/SERVLIST [<nick>`
 
-
 List network services that are currently connected to the network and visible to you. The optional glob-based nick parameter matches against the nickname of the network service.
 
 #### Example Usage


### PR DESCRIPTION
Fixes linter+Github Checks error.

```
$ ./tools/find-whitespace 
/inspircd-docs/docs/3/commands/_cmd_servlist.md has three or more consecutive empty lines!
1 problems!
```