### PR TITLE
Add a script to find broken redirects.

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,6 +14,9 @@ jobs:
             sudo apt-get install python3-pip python3-setuptools python3-wheel --assume-yes --install-recommends
             sudo pip3 install -r requirements.txt
 
+      - name: Check for broken redirects
+        run: ./tools/find-broken-redirects
+
       - name: Check for missing pages
         run: ./tools/find-missing
 

--- a/tools/find-broken-redirects
+++ b/tools/find-broken-redirects
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+require 'yaml'
+
+ROOT = File.dirname __dir__
+
+missing = Array.new
+config = YAML.load(File.read("#{ROOT}/mkdocs.yml"))
+config['plugins']['redirects']['redirect_maps'].values.each do |link|
+    next if File.exist? "#{ROOT}/docs/#{link}"
+    missing << link unless missing.include? link
+end
+
+missing.sort.each do |link|
+	absolute_link = "#{ROOT}/docs/#{link}"
+	puts "Missing redirect target: #{absolute_link}"
+end
+puts "#{missing.size} missing!"
+exit missing.size

--- a/tools/find-broken-redirects
+++ b/tools/find-broken-redirects
@@ -4,7 +4,7 @@ require 'yaml'
 ROOT = File.dirname __dir__
 
 missing = Array.new
-config = YAML.load(File.read("#{ROOT}/mkdocs.yml"))
+config = YAML.load_file "#{ROOT}/mkdocs.yml"
 config['plugins']['redirects']['redirect_maps'].values.each do |link|
     next if File.exist? "#{ROOT}/docs/#{link}"
     missing << link unless missing.include? link


### PR DESCRIPTION
CI will fail until you merge GH-80, because this script depends on the new format of `mkdocs.yml` (`plugins:` being a Hash rather than an Array)