### PR TITLE
Fixed exmaple in <hostchange>

### DIFF
--- a/docs/3/modules/hostchange.yml
+++ b/docs/3/modules/hostchange.yml
@@ -67,7 +67,7 @@ configuration:
     ```xml
     <hostchange action="addnick"
                 mask="*"
-                port="6697"
+                ports="6697"
                 suffix=".secureusers.example.com">
     ```
 


### PR DESCRIPTION
configurations states `ports` but the example has `port`

It could also maybe do an example of how to list multiple ports