### PR TITLE
Update paths to Data and Log files

### DIFF
--- a/docs/3/installation/ubuntu.md
+++ b/docs/3/installation/ubuntu.md
@@ -43,4 +43,4 @@ Configuration files are stored in `/etc/inspircd`.
 
 Data files are stored in `/var/lib/inspircd`.
 
-Log files are stored in `/usr/log/inspircd`.
+Log files are stored in `/var/log/inspircd`.

--- a/docs/3/installation/ubuntu.md
+++ b/docs/3/installation/ubuntu.md
@@ -41,6 +41,6 @@ Once you have configured your server you can start it by running `systemctl star
 
 Configuration files are stored in `/etc/inspircd`.
 
-Data files are stored in `/usr/lib/inspircd/data`.
+Data files are stored in `/var/lib/inspircd`.
 
-Log files are stored in `/usr/lib/inspircd/logs`.
+Log files are stored in `/usr/log/inspircd`.


### PR DESCRIPTION
Previous paths were out of date and referenced the /usr folder, which is no longer in use..