### PR TITLE
Mention the 'customprefix' module in the chmodes table

### DIFF
--- a/docs/3/channel-modes.md
+++ b/docs/3/channel-modes.md
@@ -85,4 +85,4 @@ Removes channel voice status from Sadie in \#channel:
 
 ### Configuration-defined modes
 
-Server administrators can also define custom modes for channel privileges, such as `q` (founder/owner), `a` (admin), or `h` (halfop), using the [customprefix](/3/modules/customprefix/) module.
+Server administrators can also define custom prefix modes for channel privileges, such as channel modes `q` (founder), `a` (admin), or `h` (halfop), using the [customprefix](/3/modules/customprefix/) module.

--- a/docs/3/channel-modes.md
+++ b/docs/3/channel-modes.md
@@ -82,3 +82,7 @@ Removes channel voice status from Sadie in \#channel:
 {# use the template defined in mkdocs_inspircd/ #}
 {% set modes = module_chmodes %}
 {% include "3/_modes_table.md" %}
+
+### Configuration-defined modes
+
+Server administrators can also define custom modes for channel privileges, such as `q` (founder/owner), `a` (admin), or `h` (halfop), using the [customprefix](/3/modules/customprefix/) module.


### PR DESCRIPTION
I was looking for a way to set these modes, and was at a loss when I couldn't find them with ctrl-f on the page.
Hopefully this should help future readers.