### PR TITLE
Dynamically fill version in page titles

### DIFF
--- a/docs/3/breaking-changes.md
+++ b/docs/3/breaking-changes.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Breaking Changes
+title: v{{ version }} Breaking Changes
 ---
 
 ## Breaking changes since InspIRCd 2

--- a/docs/3/breaking-changes.md
+++ b/docs/3/breaking-changes.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Breaking Changes
+title: v{{version}} Breaking Changes
 ---
 
 ## Breaking changes since InspIRCd 2

--- a/docs/3/change-log.md
+++ b/docs/3/change-log.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Change Log
+title: v{{ version }} Change Log
 ---
 
 ## Change Log

--- a/docs/3/change-log.md
+++ b/docs/3/change-log.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Change Log
+title: v{{version}} Change Log
 ---
 
 ## Change Log

--- a/docs/3/channel-modes.md
+++ b/docs/3/channel-modes.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Channel Modes
+title: v{{ version }} Channel Modes
 ---
 
 ## Channel Modes

--- a/docs/3/channel-modes.md
+++ b/docs/3/channel-modes.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Channel Modes
+title: v{{version}} Channel Modes
 ---
 
 ## Channel Modes

--- a/docs/3/commands/index.md
+++ b/docs/3/commands/index.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Commands
+title: v{{version}} Commands
 ---
 
 ## Commands

--- a/docs/3/commands/index.md
+++ b/docs/3/commands/index.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Commands
+title: v{{ version }} Commands
 ---
 
 ## Commands

--- a/docs/3/configuration/index.md
+++ b/docs/3/configuration/index.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Configuration
+title: v{{version}} Configuration
 ---
 
 ## Configuration

--- a/docs/3/configuration/index.md
+++ b/docs/3/configuration/index.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Configuration
+title: v{{ version }} Configuration
 ---
 
 ## Configuration

--- a/docs/3/configuration/useful-snippets.md
+++ b/docs/3/configuration/useful-snippets.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Configuration
+title: v{{version}} Configuration
 ---
 
 ## Useful Configuration Snippets

--- a/docs/3/configuration/useful-snippets.md
+++ b/docs/3/configuration/useful-snippets.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Configuration
+title: v{{ version }} Configuration
 ---
 
 ## Useful Configuration Snippets

--- a/docs/3/extended-bans.md
+++ b/docs/3/extended-bans.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Extended Bans
+title: v{{ version }} Extended Bans
 ---
 
 ## Extended Bans

--- a/docs/3/extended-bans.md
+++ b/docs/3/extended-bans.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Extended Bans
+title: v{{version}} Extended Bans
 ---
 
 ## Extended Bans

--- a/docs/3/installation/centos.md
+++ b/docs/3/installation/centos.md
@@ -1,5 +1,5 @@
 ---
-title: v3 CentOS Linux Installation
+title: v{{version}} CentOS Linux Installation
 ---
 
 ## Installing InspIRCd 3 using the CentOS package

--- a/docs/3/installation/centos.md
+++ b/docs/3/installation/centos.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} CentOS Linux Installation
+title: v{{ version }} CentOS Linux Installation
 ---
 
 ## Installing InspIRCd 3 using the CentOS package

--- a/docs/3/installation/debian.md
+++ b/docs/3/installation/debian.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Debian Linux Installation
+title: v{{ version }} Debian Linux Installation
 ---
 
 ## Installing InspIRCd 3 using the Debian package

--- a/docs/3/installation/debian.md
+++ b/docs/3/installation/debian.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Debian Linux Installation
+title: v{{version}} Debian Linux Installation
 ---
 
 ## Installing InspIRCd 3 using the Debian package

--- a/docs/3/installation/index.md
+++ b/docs/3/installation/index.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Installation
+title: v{{version}} Installation
 ---
 
 ## Installing InspIRCd 3

--- a/docs/3/installation/index.md
+++ b/docs/3/installation/index.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Installation
+title: v{{ version }} Installation
 ---
 
 ## Installing InspIRCd 3

--- a/docs/3/installation/rocky.md
+++ b/docs/3/installation/rocky.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Rocky Linux Installation
+title: v{{version}} Rocky Linux Installation
 ---
 
 ## Installing InspIRCd 3 using the Rocky Linux package

--- a/docs/3/installation/rocky.md
+++ b/docs/3/installation/rocky.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Rocky Linux Installation
+title: v{{ version }} Rocky Linux Installation
 ---
 
 ## Installing InspIRCd 3 using the Rocky Linux package

--- a/docs/3/installation/source.md
+++ b/docs/3/installation/source.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Source Installation
+title: v{{ version }} Source Installation
 ---
 
 ## Installing InspIRCd 3 from source

--- a/docs/3/installation/source.md
+++ b/docs/3/installation/source.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Source Installation
+title: v{{version}} Source Installation
 ---
 
 ## Installing InspIRCd 3 from source

--- a/docs/3/installation/ubuntu.md
+++ b/docs/3/installation/ubuntu.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Ubuntu Linux Installation
+title: v{{ version }} Ubuntu Linux Installation
 ---
 
 ## Installing InspIRCd 3 using the Ubuntu package

--- a/docs/3/installation/ubuntu.md
+++ b/docs/3/installation/ubuntu.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Ubuntu Linux Installation
+title: v{{version}} Ubuntu Linux Installation
 ---
 
 ## Installing InspIRCd 3 using the Ubuntu package

--- a/docs/3/installation/windows-source.md
+++ b/docs/3/installation/windows-source.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Windows Source Installation
+title: v{{version}} Windows Source Installation
 ---
 
 ## Installing InspIRCd 3 from source on Windows

--- a/docs/3/installation/windows-source.md
+++ b/docs/3/installation/windows-source.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Windows Source Installation
+title: v{{ version }} Windows Source Installation
 ---
 
 ## Installing InspIRCd 3 from source on Windows

--- a/docs/3/installation/windows.md
+++ b/docs/3/installation/windows.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Microsoft Windows Installation
+title: v{{ version }} Microsoft Windows Installation
 ---
 
 ## Installing InspIRCd 3 using the Windows package

--- a/docs/3/installation/windows.md
+++ b/docs/3/installation/windows.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Microsoft Windows Installation
+title: v{{version}} Microsoft Windows Installation
 ---
 
 ## Installing InspIRCd 3 using the Windows package

--- a/docs/3/module-manager.md
+++ b/docs/3/module-manager.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Module Manager
+title: v{{version}} Module Manager
 ---
 
 ## Managing third-party modules with Module Manager

--- a/docs/3/module-manager.md
+++ b/docs/3/module-manager.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Module Manager
+title: v{{ version }} Module Manager
 ---
 
 ## Managing third-party modules with Module Manager

--- a/docs/3/modules/index.md
+++ b/docs/3/modules/index.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Module List
+title: v{{ version }} Module List
 ---
 
 ## Module List

--- a/docs/3/modules/index.md
+++ b/docs/3/modules/index.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Module List
+title: v{{version}} Module List
 ---
 
 ## Module List

--- a/docs/3/snomasks.md
+++ b/docs/3/snomasks.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} Server Notice Masks
+title: v{{ version }} Server Notice Masks
 ---
 
 ## Server Notice Masks

--- a/docs/3/snomasks.md
+++ b/docs/3/snomasks.md
@@ -1,5 +1,5 @@
 ---
-title: v3 Server Notice Masks
+title: v{{version}} Server Notice Masks
 ---
 
 ## Server Notice Masks

--- a/docs/3/user-modes.md
+++ b/docs/3/user-modes.md
@@ -1,5 +1,5 @@
 ---
-title: v3 User Modes
+title: v{{version}} User Modes
 ---
 
 ## User Modes

--- a/docs/3/user-modes.md
+++ b/docs/3/user-modes.md
@@ -1,5 +1,5 @@
 ---
-title: v{{version}} User Modes
+title: v{{ version }} User Modes
 ---
 
 ## User Modes

--- a/mkdocs_inspircd/__init__.py
+++ b/mkdocs_inspircd/__init__.py
@@ -189,7 +189,9 @@ class InspircdPlugin(mkdocs.plugins.BasePlugin):
             return segments[0]
 
     def on_page_markdown(self, markdown, page, config, files):
-        """Runs Jinja on an input markdown file, to produce another markdown file."""
+        """Runs Jinja on an input markdown file, to produce another markdown file.
+        Also renders metadata at the beginning of the file as a side-effect."""
+
         env = jinja2.Environment(
             loader=jinja2.FileSystemLoader([TEMPLATES_DIR, config["docs_dir"]]),
         )
@@ -206,5 +208,13 @@ class InspircdPlugin(mkdocs.plugins.BasePlugin):
             "server_messages": self.server_messages(config),
             "version": version,
         }
+
+        # Render page metadata, by mutating arguments.
+        page.meta = {
+            k: env.from_string(v).render(context)
+            for (k, v) in page.meta.items()
+            if isinstance(v, str)
+        }
+
         template = env.from_string(markdown)
         return template.render(context)


### PR DESCRIPTION
This will allow using the same files between v3 and v4 docs without copying the whole file (just a symlink)