### PR TITLE
Fix usage example

### DIFF
--- a/docs/3/modules/spanningtree.yml
+++ b/docs/3/modules/spanningtree.yml
@@ -42,7 +42,7 @@ configuration:
 
     ```xml
     <bind address="*"
-          port="7003"
+          port="7002"
           ...
           sslprofile="Servers"
           type="servers">

--- a/docs/4/modules/spanningtree.yml
+++ b/docs/4/modules/spanningtree.yml
@@ -42,7 +42,7 @@ configuration:
 
     ```xml
     <bind address="*"
-          port="7003"
+          port="7002"
           ...
           sslprofile="Servers"
           type="servers">


### PR DESCRIPTION
The example text says

> Listens for TLS encrypted server connections on the *:7002 endpoint with a TLS (SSL) profile named "Servers":

but we used port `7003` in the shown example below.