### PR TITLE
securelist.yml: duplicate line in example

### DIFF
--- a/docs/4/modules/securelist.yml
+++ b/docs/4/modules/securelist.yml
@@ -75,7 +75,6 @@ configuration:
                 waittime="60s"
                 hidesmallchans="2"
                 fakechans="5"
-                fakechans="5"
                 fakechanprefix="#"
                 fakechantopic="Fake channel for confusing spambots">
     ```


### PR DESCRIPTION
This removes the extra `fakechans="5"`.