### PR TITLE
Add note about the version of the HAproxy protocol supported

### DIFF
--- a/docs/3/modules/haproxy.yml
+++ b/docs/3/modules/haproxy.yml
@@ -1,7 +1,7 @@
 name: haproxy
 
 description: |-
-  This module allows IRC connections to be made using reverse proxies that implement the HAProxy PROXY protocol.
+  This module allows IRC connections to be made using reverse proxies that implement version 2 of the HAProxy PROXY protocol.
 
 configuration:
 - name: bind


### PR DESCRIPTION
Small change to the documentation on the HAproxy module to explicitly state that it supports version 2 of the protocol.